### PR TITLE
Making CPANPLUS rebuilt its module tree faster (part 2)

### DIFF
--- a/lib/Params/Check.pm
+++ b/lib/Params/Check.pm
@@ -476,18 +476,17 @@ sub _clean_up_args {
 }
 
 sub _sanity_check_and_defaults {
-    my %utmpl   = %{$_[0]};
-    my %args    = %{$_[1]};
-    my $verbose = $_[2];
+    my ($utmpl, $args, $verbose) = @_;
 
     my %defs; my $fail;
-    for my $key (keys %utmpl) {
+    for my $key (keys %$utmpl) {
+        my $tmpl = $utmpl->{$key};
 
         ### check if required keys are provided
         ### keys are now lower cased, unless preserve case was enabled
         ### at which point, the utmpl keys must match, but that's the users
         ### problem.
-        if( $utmpl{$key}->{'required'} and not exists $args{$key} ) {
+        if( $tmpl->{'required'} and not exists $args->{$key} ) {
             _store_error(
                 loc(q|Required option '%1' is not provided for %2 by %3|,
                     $key, _who_was_it(1), _who_was_it(2)), $verbose );
@@ -498,8 +497,8 @@ sub _sanity_check_and_defaults {
         }
 
         ### next, set the default, make sure the key exists in %defs ###
-        $defs{$key} = $utmpl{$key}->{'default'}
-                        if exists $utmpl{$key}->{'default'};
+        $defs{$key} = $tmpl->{'default'}
+                        if exists $tmpl->{'default'};
 
         if( $SANITY_CHECK_TEMPLATE ) {
             ### last, check if they provided any weird template keys
@@ -510,13 +509,13 @@ sub _sanity_check_and_defaults {
                         $_, $key), 1, 1 );
             } grep {
                 not $known_keys{$_}
-            } keys %{$utmpl{$key}};
+            } keys %$tmpl;
 
             ### make sure you passed a ref, otherwise, complain about it!
-            if ( exists $utmpl{$key}->{'store'} ) {
+            if ( exists $tmpl->{'store'} ) {
                 _store_error( loc(
                     q|Store variable for '%1' is not a reference!|, $key
-                ), 1, 1 ) unless ref $utmpl{$key}->{'store'};
+                ), 1, 1 ) unless ref $tmpl->{'store'};
             }
         }
     }

--- a/lib/Params/Check.pm
+++ b/lib/Params/Check.pm
@@ -265,7 +265,20 @@ sub check {
     #}
 
     ### clean up the template ###
-    my $args = _clean_up_args( $href ) or return;
+    my $args;
+
+    ### don't even bother to loop, if there's nothing to clean up ###
+    if( $PRESERVE_CASE and !$STRIP_LEADING_DASHES ) {
+        $args = $href;
+    } else {
+        ### keys are not aliased ###
+        for my $key (keys %$href) {
+            my $org = $key;
+            $key = lc $key unless $PRESERVE_CASE;
+            $key =~ s/^-// if $STRIP_LEADING_DASHES;
+            $args->{$key} = $href->{$org};
+        }
+    }
 
     ### sanity check + defaults + required keys set? ###
     my $defs = _sanity_check_and_defaults( $utmpl, $args, $verbose )
@@ -448,26 +461,6 @@ sub allow {
 }
 
 ### helper functions ###
-
-### clean up the template ###
-sub _clean_up_args {
-    ### don't even bother to loop, if there's nothing to clean up ###
-    return $_[0] if $PRESERVE_CASE and !$STRIP_LEADING_DASHES;
-
-    my %args = %{$_[0]};
-
-    ### keys are note aliased ###
-    for my $key (keys %args) {
-        my $org = $key;
-        $key = lc $key unless $PRESERVE_CASE;
-        $key =~ s/^-// if $STRIP_LEADING_DASHES;
-        $args{$key} = delete $args{$org} if $key ne $org;
-    }
-
-    ### return references so we always return 'true', even on empty
-    ### arguments
-    return \%args;
-}
 
 sub _sanity_check_and_defaults {
     my ($utmpl, $args, $verbose) = @_;


### PR DESCRIPTION
These commits focus on making Params::Check::check() work faster, and this helps CPANPLUS because check() is called several times for each module of the tree. This is achieved mainly by unpacking hash refs less often. 

This pull request is best applied in conjunction with the two others that I sent for Object::Accessor and CPANPLUS, but all three are technically independent.

Vincent.
