### PR TITLE
using store to rename/alias key

### DIFF
--- a/t/01_Params-Check.t
+++ b/t/01_Params-Check.t
@@ -134,6 +134,24 @@ use constant TRUE   => sub { 1 };
     }
 }
 
+{   my $foo;
+    my $tmpl = {
+        foo => { store => 'bar' }
+    };
+
+    ### with/without store duplicates ###
+    for( 1, 0 ) {
+        local   $Params::Check::NO_DUPLICATES = $_;
+
+        my $expect = $_ ? undef : 42;
+
+        my $rv = check( $tmpl, { foo => 42 } );
+        ok( $rv,                    "check() call with store key, no_dup: $_" );
+        is( $rv->{bar}, 42,         "   found provided value in variable" );
+        is( $rv->{foo}, $expect,    "   found provided value in variable" );
+    }
+}
+
 ### no_override tests ###
 {   my $tmpl = {
         foo => { no_override => 1, default => 42 },
@@ -276,10 +294,10 @@ use constant TRUE   => sub { 1 };
 {   ### quell warnings
     local $SIG{__WARN__} = sub {};
 
-    my $tmpl = { foo => { store => '' } };
+    my $tmpl = { foo => { store => [] } };
     check( $tmpl, {} );
 
-    my $re = quotemeta q|Store variable for 'foo' is not a reference!|;
+    my $re = quotemeta q|Store variable for 'foo' is not a scalar reference|;
     like(last_error(), qr/$re/, "Caught non-reference 'store' variable" );
 }
 


### PR DESCRIPTION
Hi,

I've added a small bit of functionality to the `store` option so that it can take a scalar as well as a reference; in this case it allows renaming (subject to the _NO_DUPLICATES_ flag) of the key in the parsed argument hash.  I find this useful when passing parsed arguments on to another routine which uses alternate names.
